### PR TITLE
feat: Order history item added in user menu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Environment Variables
 * ``SITE_NAME`` - The user-facing name of the site, used as `alt` text on the logo in the header.
   Defaults to "localhost" in development.
 * ``LOGO_URL`` - The URL of the site's logo.  This logo is displayed in the header.
+* ``ORDER_HISTORY_URL`` - The URL of the order history page.
 * ``AUTHN_MINIMAL_HEADER`` - A boolean flag which hides the main menu, user menu, and logged-out
   menu items when truthy.  This is intended to be used in micro-frontends like
   frontend-app-authentication in which these menus are considered distractions from the user's task.

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -21,6 +21,7 @@ ensureConfig([
   'LOGIN_URL',
   'SITE_NAME',
   'LOGO_URL',
+  'ORDER_HISTORY_URL',
 ], 'Header component');
 
 subscribe(APP_CONFIG_INITIALIZED, () => {
@@ -55,6 +56,11 @@ function Header({ intl }) {
       type: 'item',
       href: `${config.LMS_BASE_URL}/account/settings`,
       content: intl.formatMessage(messages['header.user.menu.account.settings']),
+    },
+    {
+      type: 'item',
+      href: config.ORDER_HISTORY_URL,
+      content: intl.formatMessage(messages['header.user.menu.order.history']),
     },
     {
       type: 'item',


### PR DESCRIPTION
### Changes:

- In `Header.jsx`, the Order history item was added in the user menu using the `ORDER_HISTORY_URL` environment variable as `href`.
- `Environment Variables` section in `README.rst` updated with the description of `ORDER_HISTORY_URL`.

**Issue**: https://github.com/openedx/build-test-release-wg/issues/66
