### PR TITLE
build: pin semantic-release to v16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Build
         run: npm run build
       - name: Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 16
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npx semantic-release


### PR DESCRIPTION
Newer versions don't support node 12.