### PR TITLE
fix: update peer dependency of paragon

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^1.8.0",
-    "@edx/paragon": "^7.0.0",
+    "@edx/paragon": ">= ^7.0.0 < 13.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Upgrade peer dependency of @edx/paragon to allow for versions up to 12.x