### PR TITLE
Updated the links to use MARKETING_SITE_BASE_URL

### DIFF
--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -12,7 +12,7 @@ import messages from './messages';
 
 function AuthenticatedUserDropdown({ intl, username }) {
   const dashboardMenuItem = (
-    <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/dashboard`}>
+    <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}>
       {intl.formatMessage(messages.dashboard)}
     </Dropdown.Item>
   );
@@ -29,7 +29,7 @@ function AuthenticatedUserDropdown({ intl, username }) {
         </Dropdown.Toggle>
         <Dropdown.Menu className="dropdown-menu-right">
           {dashboardMenuItem}
-          <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/u/${username}`}>
+          <Dropdown.Item href={`${process.env.MARKETING_SITE_BASE_URL}/u/${username}`}>
             {intl.formatMessage(messages.profile)}
           </Dropdown.Item>
           <Dropdown.Item href={`${getConfig().LMS_BASE_URL}/account/settings`}>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -35,7 +35,7 @@ function LearningHeader({
   const headerLogo = (
     <LinkedLogo
       className="logo"
-      href={`${getConfig().LMS_BASE_URL}/dashboard`}
+      href={`${process.env.MARKETING_SITE_BASE_URL}/dashboard`}
       src={getConfig().LOGO_URL}
       alt={getConfig().SITE_NAME}
     />


### PR DESCRIPTION
fixes: https://github.com/mitodl/mitxonline/issues/268

From the menu in MFE in MITx Online edX, there are a couple links that need to be updated.

- "Dashboard" menu item should link to: MARKETING_SITE_URL/dashboard rather than LMS_BASE_URL/dashboard/
- "Profile" menu item should link to: MARKETING_SITE/profile rather than LMS_BASE_URL/u/USERNAME
- Also, in the menu in the 'legacy' theme, clicking on the username will take you to LMS_BASE_URL/dashboard, but should take you to MARKETING_SITE/dashboard