### PR TITLE
feat!: Remove Studio Maintenance link (attempt 2)

### DIFF
--- a/src/Header.messages.jsx
+++ b/src/Header.messages.jsx
@@ -61,11 +61,6 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to the Studio Home',
   },
-  'header.user.menu.studio.maintenance': {
-    id: 'header.user.menu.studio.maintenance',
-    defaultMessage: 'Maintenance',
-    description: 'Link to the Studio Maintenance',
-  },
   'header.label.account.nav': {
     id: 'header.label.account.nav',
     defaultMessage: 'Account',

--- a/src/studio-header/StudioHeader.test.tsx
+++ b/src/studio-header/StudioHeader.test.tsx
@@ -12,7 +12,6 @@ import { Context as ResponsiveContext } from 'react-responsive';
 import { MemoryRouter } from 'react-router-dom';
 
 import StudioHeader from './StudioHeader';
-import messages from './messages';
 
 const authenticatedUser = {
   userId: 3,
@@ -119,16 +118,6 @@ describe('Header', () => {
       expect(dropdownOption).toBeVisible();
     });
 
-    it('maintenance should not be in user menu', async () => {
-      currentUser = { ...authenticatedUser, administrator: false };
-      const { getAllByRole, queryByText } = render(<RootWrapper {...props} />);
-      const userMenu = getAllByRole('button')[1];
-      await waitFor(() => fireEvent.click(userMenu));
-      const maintenanceButton = queryByText(messages['header.user.menu.maintenance'].defaultMessage);
-
-      expect(maintenanceButton).toBeNull();
-    });
-
     it('user menu should use avatar icon', async () => {
       currentUser = { ...authenticatedUser, avatar: null };
       const { getByTestId } = render(<RootWrapper {...props} />);
@@ -188,15 +177,6 @@ describe('Header', () => {
       const desktopMenu = queryByTestId('desktop-menu');
 
       expect(desktopMenu).toBeNull();
-    });
-
-    it('maintenance should be in user menu', async () => {
-      const { getAllByRole, getByText } = render(<RootWrapper {...props} />);
-      const userMenu = getAllByRole('button')[1];
-      await waitFor(() => fireEvent.click(userMenu));
-      const maintenanceButton = getByText(messages['header.user.menu.maintenance'].defaultMessage);
-
-      expect(maintenanceButton).toBeVisible();
     });
 
     it('user menu should use avatar image', async () => {

--- a/src/studio-header/messages.ts
+++ b/src/studio-header/messages.ts
@@ -6,11 +6,6 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to Studio Home',
   },
-  'header.user.menu.maintenance': {
-    id: 'header.user.menu.maintenance',
-    defaultMessage: 'Maintenance',
-    description: 'Link to the Studio maintenance page',
-  },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',
     defaultMessage: 'Logout',

--- a/src/studio-header/utils.ts
+++ b/src/studio-header/utils.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
 const getUserMenuItems = ({
@@ -21,9 +20,6 @@ const getUserMenuItems = ({
       {
         href: `${studioBaseUrl}`,
         title: intl.formatMessage(messages['header.user.menu.studio']),
-      }, {
-        href: `${getConfig().STUDIO_BASE_URL}/maintenance`,
-        title: intl.formatMessage(messages['header.user.menu.maintenance']),
       }, {
         href: `${logoutUrl}`,
         title: intl.formatMessage(messages['header.user.menu.logout']),


### PR DESCRIPTION
## Description

This reverts commit 48c49fe0b2e5867ff9fb38185d6c1321d482716e.

The original commit (a229c345353407b5afa06e9ab8a91638ef59da2b) was merged prematurely, so it was reverted. However, now that we have properly DEPR'd the underlying feature, we can revert that revert.

Part of: https://github.com/openedx/edx-platform/issues/36263

## Screenshots

This removes the "Maintenance" link here:

<img width="527" height="220" alt="image" src="https://github.com/user-attachments/assets/6e2e9afc-df70-483d-a8a6-0973103a8173" />
