### PR TITLE
Manuel star do/release/v20.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release CI
 on:
   push:
     branches:
-    - master
-    - alpha
+    - nau/*.master
+
 jobs:
   release:
     name: Release
@@ -38,10 +38,7 @@ jobs:
         fail_ci_if_error: false
     - name: Build
       run: npm run build
-    - name: Release
-      uses: cycjimmy/semantic-release-action@v3
+    - name: Release to npmjs
+      uses: JS-DevTools/npm-publish@v3
       with:
-        semantic_version: 16
-      env:
-        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+        token: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Environment Variables
 * ``AUTHN_MINIMAL_HEADER`` - A boolean flag which hides the main menu, user menu, and logged-out
   menu items when truthy.  This is intended to be used in micro-frontends like
   frontend-app-authentication in which these menus are considered distractions from the user's task.
+* ``ENABLE_HEADER_LANG_SELECTOR`` - A boolean to enable the language selector in the header component.
+* ``SITE_SUPPORTED_LANGUAGES`` - A list with all the languages to display in the selector.
+
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Environment Variables
   frontend-app-authentication in which these menus are considered distractions from the user's task.
 * ``ENABLE_HEADER_LANG_SELECTOR`` - A boolean to enable the language selector in the header component.
 * ``SITE_SUPPORTED_LANGUAGES`` - A list with all the languages to display in the selector.
+* ``LOGO_URL_MOBILE`` - The URL of the site's logo for mobile. This logo is displayed in the header.
 
 
 Installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.0.0",
+  "version": "18.1.0",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.2.0",
+  "version": "18.2.1",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.1.2",
+  "version": "18.2.0",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "18.2.1",
+  "version": "20.0.0",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@edx/frontend-component-header",
-  "version": "1.0.0-semantically-released",
-  "description": "The standard header for Open edX",
+  "name": "@nauedu/frontend-component-header",
+  "version": "18.0.0",
+  "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -22,14 +22,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/frontend-component-header.git"
+    "url": "git+https://github.com/fccn/frontend-component-header-nau.git"
   },
   "author": "edX",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/openedx/frontend-component-header/issues"
+    "url": "https://github.com/fccn/frontend-component-header-nau/issues"
   },
-  "homepage": "https://github.com/openedx/frontend-component-header#readme",
+  "homepage": "https://github.com/fccn/frontend-component-header-nau#readme",
   "devDependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nauedu/frontend-component-header",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "NAU header component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -28,7 +28,7 @@ ensureConfig([
 subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
-    ENABLED_ORG_LOGO: !!process.env.ENABLED_ORG_LOGO,
+    ENABLE_ORG_LOGO: !!process.env.ENABLE_ORG_LOGO,
   }, 'Header additional config');
 });
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -3,7 +3,7 @@ import Responsive from 'react-responsive';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
-  APP_CONFIG_INITIALIZED,
+  APP_PUBSUB_INITIALIZED,
   ensureConfig,
   mergeConfig,
   getConfig,
@@ -25,7 +25,7 @@ ensureConfig([
   'ORDER_HISTORY_URL',
 ], 'Header component');
 
-subscribe(APP_CONFIG_INITIALIZED, () => {
+subscribe(APP_PUBSUB_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
     ENABLE_ORG_LOGO: !!process.env.ENABLE_ORG_LOGO,

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -28,6 +28,7 @@ ensureConfig([
 subscribe(APP_CONFIG_INITIALIZED, () => {
   mergeConfig({
     AUTHN_MINIMAL_HEADER: !!process.env.AUTHN_MINIMAL_HEADER,
+    ENABLED_ORG_LOGO: !!process.env.ENABLED_ORG_LOGO,
   }, 'Header additional config');
 });
 

--- a/src/LanguageSelector/data/api.js
+++ b/src/LanguageSelector/data/api.js
@@ -1,0 +1,32 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { convertKeyNames, snakeCaseObject } from '@edx/frontend-platform/utils';
+
+export async function patchPreferences(username, params) {
+  let processedParams = snakeCaseObject(params);
+  processedParams = convertKeyNames(processedParams, {
+    pref_lang: 'pref-lang',
+  });
+
+  await getAuthenticatedHttpClient()
+    .patch(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`, processedParams, {
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+    });
+
+  return params;
+}
+
+export async function postSetLang(code) {
+  const formData = new FormData();
+  const requestConfig = {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  };
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
+  formData.append('language', code);
+
+  await getAuthenticatedHttpClient()
+    .post(url, formData, requestConfig);
+}

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGlobe } from '@fortawesome/free-solid-svg-icons';
 import { publish } from '@edx/frontend-platform';
 import {
   getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
 } from '@edx/frontend-platform/i18n';
+import { Dropdown } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { patchPreferences, postSetLang } from './data/api';
@@ -24,10 +27,8 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 const LanguageSelector = ({
   intl, options, authenticatedUser, ...props
 }) => {
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
-    const languageCode = e.target.elements['site-header-language-select'].value;
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
 
     if (previousSiteLanguage !== languageCode) {
@@ -36,37 +37,18 @@ const LanguageSelector = ({
   };
 
   return (
-    <form
-      className="form-inline"
-      onSubmit={handleSubmit}
-      {...props}
-    >
-      <div className="form-group d-wrap">
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label htmlFor="site-header-language-select" className="d-inline-block m-0 small">
-          <FormattedMessage
-            id="footer.languageForm.select.label"
-            defaultMessage="Choose Language"
-            description="The label for the laguage select part of the language selection form."
-          />
-        </label>
-        <select
-          id="site-header-language-select"
-          className="form-control-sm mx-2"
-          name="site-header-language-select"
-          defaultValue={intl.locale}
-        >
-          {options.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
-        </select>
-        <button data-testid="site-header-submit-btn" className="btn btn-outline-primary btn-sm" type="submit">
-          <FormattedMessage
-            id="footer.languageForm.submit.label"
-            defaultMessage="Apply"
-            description="The label for button to submit the language selection form."
-          />
-        </button>
-      </div>
-    </form>
+    <Dropdown className="language-selector" >
+      <Dropdown.Toggle variant="outline-primary">
+        <FontAwesomeIcon icon={faGlobe} />
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+      {options.map(({ value, label }) => (
+        <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
+          {label}
+        </Dropdown.Item>
+      ))}
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -25,8 +25,14 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, ...props
+  intl, options, authenticatedUser, compact, ...props
 }) => {
+
+  const languageLabel = (languageCode) => {
+    const option = options.find( ({ value, label }) => value === languageCode )
+    return option ? option.label : null
+  }
+
   const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
@@ -34,21 +40,43 @@ const LanguageSelector = ({
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
+
+    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
   };
 
+  const currentLangLabel = languageLabel(intl.locale)
+  const showLabel = !Boolean(compact || false);
+
   return (
-    <Dropdown className="language-selector" >
-      <Dropdown.Toggle variant="outline-primary">
-        <FontAwesomeIcon icon={faGlobe} />
-      </Dropdown.Toggle>
-      <Dropdown.Menu>
-      {options.map(({ value, label }) => (
-        <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
-          {label}
-        </Dropdown.Item>
-      ))}
-      </Dropdown.Menu>
-    </Dropdown>
+    <>
+      <Dropdown className="language-selector">
+        <Dropdown.Toggle variant="outline-primary">
+          <FontAwesomeIcon icon={faGlobe} />
+          {showLabel && (
+            currentLangLabel ? (
+              <span class="pl-1 languageLabel">
+                {currentLangLabel}
+              </span>
+            ) : (
+              <span class="pl-1">
+                <FormattedMessage
+                  id="footer.languageForm.select.label"
+                  defaultMessage="Choose Language"
+                  description="The label for the laguage select part of the language selection form."
+                />
+              </span>
+            )
+          )}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+        {options.map(({ value, label }) => (
+          <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
+            {label}
+          </Dropdown.Item>
+        ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
   );
 };
 
@@ -57,6 +85,7 @@ LanguageSelector.propTypes = {
     username: PropTypes.string,
   }).isRequired,
   intl: intlShape.isRequired,
+  compact: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string,
     label: PropTypes.string,

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { publish } from '@edx/frontend-platform';
+import {
+  getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
+} from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { patchPreferences, postSetLang } from './data/api';
+
+const onLanguageSelected = async (username, selectedLanguageCode) => {
+  try {
+    if (username) {
+      await patchPreferences(username, { prefLang: selectedLanguageCode });
+      await postSetLang(selectedLanguageCode);
+    }
+    publish(LOCALE_CHANGED, getLocale());
+    handleRtl();
+  } catch (error) {
+    logError(error);
+  }
+};
+
+const LanguageSelector = ({
+  intl, options, authenticatedUser, ...props
+}) => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const previousSiteLanguage = getLocale();
+    const languageCode = e.target.elements['site-header-language-select'].value;
+    console.debug(previousSiteLanguage, languageCode, authenticatedUser);
+
+    if (previousSiteLanguage !== languageCode) {
+      onLanguageSelected(authenticatedUser?.username, languageCode);
+    }
+  };
+
+  return (
+    <form
+      className="form-inline"
+      onSubmit={handleSubmit}
+      {...props}
+    >
+      <div className="form-group d-wrap">
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label htmlFor="site-header-language-select" className="d-inline-block m-0 small">
+          <FormattedMessage
+            id="footer.languageForm.select.label"
+            defaultMessage="Choose Language"
+            description="The label for the laguage select part of the language selection form."
+          />
+        </label>
+        <select
+          id="site-header-language-select"
+          className="form-control-sm mx-2"
+          name="site-header-language-select"
+          defaultValue={intl.locale}
+        >
+          {options.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
+        </select>
+        <button data-testid="site-header-submit-btn" className="btn btn-outline-primary btn-sm" type="submit">
+          <FormattedMessage
+            id="footer.languageForm.submit.label"
+            defaultMessage="Apply"
+            description="The label for button to submit the language selection form."
+          />
+        </button>
+      </div>
+    </form>
+  );
+};
+
+LanguageSelector.propTypes = {
+  authenticatedUser: PropTypes.shape({
+    username: PropTypes.string,
+  }).isRequired,
+  intl: intlShape.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string,
+    label: PropTypes.string,
+  })).isRequired,
+};
+
+export default injectIntl(LanguageSelector);

--- a/src/LanguageSelector/index.jsx
+++ b/src/LanguageSelector/index.jsx
@@ -25,58 +25,57 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, compact, ...props
+  intl, options, authenticatedUser, compact,
 }) => {
-
   const languageLabel = (languageCode) => {
-    const option = options.find( ({ value, label }) => value === languageCode )
-    return option ? option.label : null
-  }
+    const option = options.find(({ value }) => value === languageCode);
+    return option ? option.label : null;
+  };
 
   const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
+    /* eslint-disable no-console */
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
 
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
 
-    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
+    const languageLabelElement = event.target.parentElement.parentElement.querySelector('.languageLabel');
+    languageLabelElement.innerHTML = languageLabel(languageCode);
   };
 
-  const currentLangLabel = languageLabel(intl.locale)
-  const showLabel = !Boolean(compact || false);
+  const currentLangLabel = languageLabel(intl.locale);
+  const showLabel = !(compact || false);
 
   return (
-    <>
-      <Dropdown className="language-selector">
-        <Dropdown.Toggle variant="outline-primary">
-          <FontAwesomeIcon icon={faGlobe} />
-          {showLabel && (
-            currentLangLabel ? (
-              <span class="pl-1 languageLabel">
-                {currentLangLabel}
-              </span>
-            ) : (
-              <span class="pl-1">
-                <FormattedMessage
-                  id="footer.languageForm.select.label"
-                  defaultMessage="Choose Language"
-                  description="The label for the laguage select part of the language selection form."
-                />
-              </span>
-            )
-          )}
-        </Dropdown.Toggle>
-        <Dropdown.Menu>
+    <Dropdown className="language-selector">
+      <Dropdown.Toggle variant="outline-primary">
+        <FontAwesomeIcon icon={faGlobe} />
+        {showLabel && (
+          currentLangLabel ? (
+            <span className="pl-1 languageLabel">
+              {currentLangLabel}
+            </span>
+          ) : (
+            <span className="pl-1">
+              <FormattedMessage
+                id="footer.languageForm.select.label"
+                defaultMessage="Choose Language"
+                description="The label for the laguage select part of the language selection form."
+              />
+            </span>
+          )
+        )}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
         {options.map(({ value, label }) => (
           <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
             {label}
           </Dropdown.Item>
         ))}
-        </Dropdown.Menu>
-      </Dropdown>
-    </>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 
@@ -90,6 +89,10 @@ LanguageSelector.propTypes = {
     value: PropTypes.string,
     label: PropTypes.string,
   })).isRequired,
+};
+
+LanguageSelector.defaultProps = {
+  compact: false,
 };
 
 export default injectIntl(LanguageSelector);

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -28,7 +28,7 @@ exports[`<Header /> renders correctly for anonymous desktop 1`] = `
       </a>
       <nav
         aria-label="Main"
-        className="nav main-nav"
+        className="nav main-nav mr-auto"
       >
         <a
           className="nav-link"
@@ -40,7 +40,7 @@ exports[`<Header /> renders correctly for anonymous desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <a
           className="btn mr-2 btn-link"
@@ -225,7 +225,7 @@ exports[`<Header /> renders correctly for authenticated desktop 1`] = `
       </a>
       <nav
         aria-label="Main"
-        className="nav main-nav"
+        className="nav main-nav mr-auto"
       >
         <a
           className="nav-link"
@@ -237,7 +237,7 @@ exports[`<Header /> renders correctly for authenticated desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <div
           className="menu null"

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -21,7 +21,7 @@ import { desktopUserMenuDataShape } from './DesktopHeaderUserMenu';
 import messages from '../Header.messages';
 
 // Assets
-import LanguageSelector from './LanguageSelector';
+import LanguageSelector from '../LanguageSelector';
 
 class DesktopHeader extends React.Component {
   constructor(props) { // eslint-disable-line @typescript-eslint/no-useless-constructor

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -93,7 +93,7 @@ class DesktopHeader extends React.Component {
 			{getConfig().ENABLE_HEADER_LANG_SELECTOR && (
               <div className="mx-2">
                 <LanguageSelector
-                  options={getConfig().SITE_SUPPORTED_LENGUAGES}
+                  options={getConfig().SITE_SUPPORTED_LANGUAGES}
                   authenticatedUser={getAuthenticatedUser()}
                 />
               </div>

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 // Local Components
 import DesktopUserMenuToggleSlot
@@ -20,6 +21,7 @@ import { desktopUserMenuDataShape } from './DesktopHeaderUserMenu';
 import messages from '../Header.messages';
 
 // Assets
+import LanguageSelector from './LanguageSelector';
 
 class DesktopHeader extends React.Component {
   constructor(props) { // eslint-disable-line @typescript-eslint/no-useless-constructor
@@ -84,13 +86,21 @@ class DesktopHeader extends React.Component {
             <LogoSlot {...logoProps} />
             <nav
               aria-label={intl.formatMessage(messages['header.label.main.nav'])}
-              className="nav main-nav"
+              className="nav main-nav mr-auto"
             >
               {this.renderMainMenu()}
             </nav>
+			{getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+              <div className="mx-2">
+                <LanguageSelector
+                  options={getConfig().SITE_SUPPORTED_LENGUAGES}
+                  authenticatedUser={getAuthenticatedUser()}
+                />
+              </div>
+            )}
             <nav
               aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}
-              className="nav secondary-menu-container align-items-center ml-auto"
+              className="nav secondary-menu-container align-items-center"
             >
               {loggedIn
                 ? (

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -93,7 +93,7 @@ class DesktopHeader extends React.Component {
 			{getConfig().ENABLE_HEADER_LANG_SELECTOR && (
               <div className="mx-2">
                 <LanguageSelector
-                  options={getConfig().SITE_SUPPORTED_LANGUAGES}
+                  options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
                   authenticatedUser={getAuthenticatedUser()}
                 />
               </div>

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -90,13 +90,13 @@ class DesktopHeader extends React.Component {
             >
               {this.renderMainMenu()}
             </nav>
-			{getConfig().ENABLE_HEADER_LANG_SELECTOR && (
-              <div className="mx-2">
-                <LanguageSelector
-                  options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                  authenticatedUser={getAuthenticatedUser()}
-                />
-              </div>
+            {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+            <div className="mx-2">
+              <LanguageSelector
+                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                authenticatedUser={getAuthenticatedUser()}
+              />
+            </div>
             )}
             <nav
               aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}

--- a/src/index.scss
+++ b/src/index.scss
@@ -44,8 +44,13 @@ $rounded-pill: 50rem  !default;
     }
   }
 
-  .user-dropdown .btn {
-    height: 3rem;
+  .user-dropdown {
+    .btn {
+      height: 3rem;
+      @media (map-get($grid-breakpoints, "sm")) {
+        padding: 0 0.5rem;
+      }
+    }
   }
 }
 

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -70,7 +70,7 @@ const LearningHeader = ({
           </div>
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
-          <div className="mx-2 d-none d-md-inline-flex">
+          <div className="mx-2 d-md-inline-flex">
             <LanguageSelector
               options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
               authenticatedUser={authenticatedUser}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -65,7 +65,7 @@ const LearningHeader = ({
   return (
     <header className="learning-header">
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
-      <div className="container-xl py-2 d-flex align-items-center">
+      <div className="container-xl py-2 d-flex align-items-center justify-content-between">
         {headerLogo}
         <div className="d-none d-md-block flex-grow-1 course-title-lockup">
           <div className={`d-md-flex ${enableOrgLogo && 'align-items-center justify-content-center'} w-100`}>
@@ -80,23 +80,34 @@ const LearningHeader = ({
             </span>
           </div>
         </div>
-        {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
-          <div className="mx-2 d-md-inline-flex">
-            <LanguageSelector
-              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-              compact
-              authenticatedUser={authenticatedUser}
+        <div className="d-flex align-items-center">
+          {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+            <div className="mx-2 d-md-inline-flex">
+              <Responsive maxWidth={1200}>
+                <LanguageSelector
+                  options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                  compact
+                  authenticatedUser={authenticatedUser}
+                />
+              </Responsive>
+              <Responsive minWidth={1200}>
+                <LanguageSelector
+                  options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                  compact={false}
+                  authenticatedUser={authenticatedUser}
+                />
+              </Responsive>
+            </div>
+          )}
+          {showUserDropdown && authenticatedUser && (
+            <AuthenticatedUserDropdown
+              username={authenticatedUser.username}
             />
-          </div>
-        )}
-        {showUserDropdown && authenticatedUser && (
-          <AuthenticatedUserDropdown
-            username={authenticatedUser.username}
-          />
-        )}
-        {showUserDropdown && !authenticatedUser && (
-          <AnonymousUserMenu />
-        )}
+          )}
+          {showUserDropdown && !authenticatedUser && (
+            <AnonymousUserMenu />
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -86,7 +86,7 @@ const LearningHeader = ({
             <Responsive maxWidth={1000}>
               <LanguageSelector
                 options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact={true}
+                compact
                 authenticatedUser={authenticatedUser}
               />
             </Responsive>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -8,8 +8,6 @@ import { AppContext } from '@edx/frontend-platform/react';
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
 import LogoSlot from '../plugin-slots/LogoSlot';
-import CourseInfoSlot from '../plugin-slots/CourseInfoSlot';
-import { courseInfoDataShape } from './LearningHeaderCourseInfo';
 import messages from './messages';
 import getCourseLogoOrg from './data/api';
 import LanguageSelector from '../LanguageSelector';

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -72,7 +72,7 @@ const LearningHeader = ({
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-none d-md-inline-flex">
             <LanguageSelector
-              options={JSON.parse(getConfig().SITE_SUPPORTED_LENGUAGES)}
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
               authenticatedUser={authenticatedUser}
             />
           </div>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -29,6 +29,10 @@ LinkedLogo.propTypes = {
   alt: PropTypes.string.isRequired,
 };
 
+// this feature flag is not included on the frontend-platform, we have to get it directly from ENV
+const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
+
+
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
@@ -54,17 +58,19 @@ const LearningHeader = ({
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
-        <div className="flex-grow-1 course-title-lockup text-center" style={{ lineHeight: 1 }}>
-          {
-            (courseOrg && logoOrg)
-            && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '50px' }} />
-          }
-          <span
-            className="d-inline-block course-title font-weight-bold ml-3 overflow-hidden text-nowrap text-left w-25"
-            style={{ textOverflow: 'ellipsis' }}
-          >
-            {courseTitle}
-          </span>
+        <div className="d-none d-md-block flex-grow-1 course-title-lockup">
+          <div className={`d-md-flex ${enabledOrgLogo && 'align-items-center justify-content-center'} w-100`}>
+            {enabledOrgLogo ? (
+              (courseOrg && logoOrg)
+              && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '45px' }} />
+            ) : null}
+            <span
+              className="d-inline-block course-title font-weight-semibold ml-3 text-truncate text-left w-25"
+              style={{ fontSize: '0.85rem' }}
+            >
+              {courseTitle}
+            </span>
+          </div>
         </div>
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -69,13 +69,12 @@ const LearningHeader = ({
         {headerLogo}
         <div className="d-none d-md-block flex-grow-1 course-title-lockup">
           <div className={`d-md-flex ${enableOrgLogo && 'align-items-center justify-content-center'} w-100`}>
-            {enableOrgLogo ? (
-              (courseOrg && logoOrg)
-              && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '45px' }} />
-            ) : null}
+            {enableOrgLogo && courseOrg && logoOrg && (
+              <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '3rem', maxWidth: '15rem' }} />
+            )}
             <span
-              className="d-inline-block course-title font-weight-semibold ml-3 text-truncate text-left w-25"
-              style={{ fontSize: '0.85rem' }}
+              className="d-inline-block course-title font-weight-semibold ml-3 text-truncate text-left"
+              style={{ fontSize: '1rem' }}
             >
               {courseTitle}
             </span>
@@ -83,14 +82,14 @@ const LearningHeader = ({
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-md-inline-flex">
-            <Responsive maxWidth={1000}>
+            <Responsive maxWidth={1200}>
               <LanguageSelector
                 options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
                 compact
                 authenticatedUser={authenticatedUser}
               />
             </Responsive>
-            <Responsive minWidth={1000}>
+            <Responsive minWidth={1200}>
               <LanguageSelector
                 options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
                 compact={false}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -8,6 +8,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
 import LogoSlot from '../plugin-slots/LogoSlot';
+import LearningHelpSlot from '../plugin-slots/LearningHelpSlot';
 import messages from './messages';
 import getCourseLogoOrg from './data/api';
 import LanguageSelector from '../LanguageSelector';
@@ -98,9 +99,12 @@ const LearningHeader = ({
             </div>
           )}
           {showUserDropdown && authenticatedUser && (
-            <AuthenticatedUserDropdown
-              username={authenticatedUser.username}
-            />
+            <>
+              <LearningHelpSlot />
+              <AuthenticatedUserDropdown
+                username={authenticatedUser.username}
+              />
+            </>
           )}
           {showUserDropdown && !authenticatedUser && (
             <AnonymousUserMenu />

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -32,7 +32,6 @@ LinkedLogo.propTypes = {
 // this feature flag is not included on the frontend-platform, we have to get it directly from ENV
 const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
 
-
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
@@ -43,7 +42,7 @@ const LearningHeader = ({
     if (courseOrg) {
       getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
     }
-  }, []);
+  });
 
   const headerLogo = (
     <LogoSlot

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -72,7 +72,7 @@ const LearningHeader = ({
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-none d-md-inline-flex">
             <LanguageSelector
-              options={getConfig().SITE_SUPPORTED_LENGUAGES}
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LENGUAGES)}
               authenticatedUser={authenticatedUser}
             />
           </div>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -28,15 +28,12 @@ LinkedLogo.propTypes = {
   src: PropTypes.string.isRequired,
   alt: PropTypes.string.isRequired,
 };
-
-// this feature flag is not included on the frontend-platform, we have to get it directly from ENV
-const enabledOrgLogo = process.env.ENABLED_ORG_LOGO || false;
-
 const LearningHeader = ({
   courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
+  const enabledOrgLogo = getConfig().ENABLED_ORG_LOGO || false;
 
   useEffect(() => {
     if (courseOrg) {

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -83,10 +83,20 @@ const LearningHeader = ({
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-md-inline-flex">
-            <LanguageSelector
-              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-              authenticatedUser={authenticatedUser}
-            />
+            <Responsive maxWidth={1000}>
+              <LanguageSelector
+                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                compact={true}
+                authenticatedUser={authenticatedUser}
+              />
+            </Responsive>
+            <Responsive minWidth={1000}>
+              <LanguageSelector
+                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+                compact={false}
+                authenticatedUser={authenticatedUser}
+              />
+            </Responsive>
           </div>
         )}
         {showUserDropdown && authenticatedUser && (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -11,6 +11,7 @@ import CourseInfoSlot from '../plugin-slots/CourseInfoSlot';
 import { courseInfoDataShape } from './LearningHeaderCourseInfo';
 import messages from './messages';
 import getCourseLogoOrg from './data/api';
+import LanguageSelector from '../LanguageSelector';
 
 const LinkedLogo = ({
   href,
@@ -68,6 +69,14 @@ const LearningHeader = ({
             </span>
           </div>
         </div>
+        {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
+          <div className="mx-2 d-none d-md-inline-flex">
+            <LanguageSelector
+              options={getConfig().SITE_SUPPORTED_LENGUAGES}
+              authenticatedUser={authenticatedUser}
+            />
+          </div>
+        )}
         {showUserDropdown && authenticatedUser && (
           <AuthenticatedUserDropdown
             username={authenticatedUser.username}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -33,7 +33,7 @@ const LearningHeader = ({
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
-  const enabledOrgLogo = getConfig().ENABLED_ORG_LOGO || false;
+  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO || false;
 
   useEffect(() => {
     if (courseOrg) {
@@ -55,8 +55,8 @@ const LearningHeader = ({
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
         <div className="d-none d-md-block flex-grow-1 course-title-lockup">
-          <div className={`d-md-flex ${enabledOrgLogo && 'align-items-center justify-content-center'} w-100`}>
-            {enabledOrgLogo ? (
+          <div className={`d-md-flex ${enableOrgLogo && 'align-items-center justify-content-center'} w-100`}>
+            {enableOrgLogo ? (
               (courseOrg && logoOrg)
               && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '45px' }} />
             ) : null}

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -82,20 +82,11 @@ const LearningHeader = ({
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (
           <div className="mx-2 d-md-inline-flex">
-            <Responsive maxWidth={1200}>
-              <LanguageSelector
-                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact
-                authenticatedUser={authenticatedUser}
-              />
-            </Responsive>
-            <Responsive minWidth={1200}>
-              <LanguageSelector
-                options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
-                compact={false}
-                authenticatedUser={authenticatedUser}
-              />
-            </Responsive>
+            <LanguageSelector
+              options={JSON.parse(getConfig().SITE_SUPPORTED_LANGUAGES)}
+              compact
+              authenticatedUser={authenticatedUser}
+            />
           </div>
         )}
         {showUserDropdown && authenticatedUser && (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -35,13 +35,13 @@ const LearningHeader = ({
 }) => {
   const { authenticatedUser } = useContext(AppContext);
   const [logoOrg, setLogoOrg] = useState(null);
-  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO || false;
+  const enableOrgLogo = getConfig().ENABLE_ORG_LOGO;
 
   useEffect(() => {
-    if (courseOrg) {
+    if (courseOrg && enableOrgLogo) {
       getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
     }
-  });
+  }, [courseOrg, enableOrgLogo]);
 
   const headerLogo = (
     <>

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
+import Responsive from 'react-responsive';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -43,11 +44,22 @@ const LearningHeader = ({
   });
 
   const headerLogo = (
-    <LogoSlot
-      href={`${getConfig().LMS_BASE_URL}/dashboard`}
-      src={getConfig().LOGO_URL}
-      alt={getConfig().SITE_NAME}
-    />
+    <>
+      <Responsive maxWidth={769}>
+        <LogoSlot
+          href={`${getConfig().LMS_BASE_URL}/dashboard`}
+          src={getConfig().LOGO_URL_MOBILE || getConfig().LOGO_URL}
+          alt={getConfig().SITE_NAME}
+        />
+      </Responsive>
+      <Responsive minWidth={769}>
+        <LogoSlot
+          href={`${getConfig().LMS_BASE_URL}/dashboard`}
+          src={getConfig().LOGO_URL}
+          alt={getConfig().SITE_NAME}
+        />
+      </Responsive>
+    </>
   );
 
   return (

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -10,12 +10,36 @@ import LogoSlot from '../plugin-slots/LogoSlot';
 import CourseInfoSlot from '../plugin-slots/CourseInfoSlot';
 import { courseInfoDataShape } from './LearningHeaderCourseInfo';
 import messages from './messages';
-import LearningHelpSlot from '../plugin-slots/LearningHelpSlot';
+import getCourseLogoOrg from './data/api';
+
+const LinkedLogo = ({
+  href,
+  src,
+  alt,
+  ...attributes
+}) => (
+  <a href={href} {...attributes}>
+    <img className="d-block" src={src} alt={alt} />
+  </a>
+);
+
+LinkedLogo.propTypes = {
+  href: PropTypes.string.isRequired,
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+};
 
 const LearningHeader = ({
-  courseOrg, courseNumber, courseTitle, intl, showUserDropdown,
+  courseOrg, courseTitle, intl, showUserDropdown,
 }) => {
   const { authenticatedUser } = useContext(AppContext);
+  const [logoOrg, setLogoOrg] = useState(null);
+
+  useEffect(() => {
+    if (courseOrg) {
+      getCourseLogoOrg().then((logoOrgUrl) => { setLogoOrg(logoOrgUrl); });
+    }
+  }, []);
 
   const headerLogo = (
     <LogoSlot
@@ -30,19 +54,25 @@ const LearningHeader = ({
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
-        <div className="flex-grow-1 course-title-lockup d-flex" style={{ lineHeight: 1 }}>
-          <CourseInfoSlot courseOrg={courseOrg} courseNumber={courseNumber} courseTitle={courseTitle} />
+        <div className="flex-grow-1 course-title-lockup text-center" style={{ lineHeight: 1 }}>
+          {
+            (courseOrg && logoOrg)
+            && <img src={logoOrg} alt={`${courseOrg} logo`} style={{ maxHeight: '50px' }} />
+          }
+          <span
+            className="d-inline-block course-title font-weight-bold ml-3 overflow-hidden text-nowrap text-left w-25"
+            style={{ textOverflow: 'ellipsis' }}
+          >
+            {courseTitle}
+          </span>
         </div>
         {showUserDropdown && authenticatedUser && (
-        <>
-          <LearningHelpSlot />
           <AuthenticatedUserDropdown
             username={authenticatedUser.username}
           />
-        </>
         )}
         {showUserDropdown && !authenticatedUser && (
-        <AnonymousUserMenu />
+          <AnonymousUserMenu />
         )}
       </div>
     </header>
@@ -50,16 +80,14 @@ const LearningHeader = ({
 };
 
 LearningHeader.propTypes = {
-  courseOrg: courseInfoDataShape.courseOrg,
-  courseNumber: courseInfoDataShape.courseNumber,
-  courseTitle: courseInfoDataShape.courseTitle,
+  courseOrg: PropTypes.string,
+  courseTitle: PropTypes.string,
   intl: intlShape.isRequired,
   showUserDropdown: PropTypes.bool,
 };
 
 LearningHeader.defaultProps = {
   courseOrg: null,
-  courseNumber: null,
   courseTitle: null,
   showUserDropdown: true,
 };

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -27,7 +27,6 @@ describe('Header', () => {
     render(<Header {...courseData} />);
     waitFor(
       () => {
-
         expect(screen.getByAltText(`${courseData.courseOrg} logo`)).toHaveAttribute('src', 'logo-url');
         expect(screen.getByText(`${courseData.courseOrg}`)).toBeInTheDocument();
         expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();

--- a/src/learning-header/LearningHeader.test.jsx
+++ b/src/learning-header/LearningHeader.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import {
-  authenticatedUser, initializeMockApp, render, screen,
+  authenticatedUser, initializeMockApp, render, screen, waitFor,
 } from '../setupTest';
 import { LearningHeader as Header } from '../index';
+
+jest.mock('./data/api', () => ({
+  getCourseLogoOrg: jest.fn().mockResolvedValue(Promise.resolve('logo-url')),
+}));
 
 describe('Header', () => {
   beforeAll(async () => {
@@ -18,12 +22,16 @@ describe('Header', () => {
   it('displays course data', () => {
     const courseData = {
       courseOrg: 'course-org',
-      courseNumber: 'course-number',
       courseTitle: 'course-title',
     };
     render(<Header {...courseData} />);
+    waitFor(
+      () => {
 
-    expect(screen.getByText(`${courseData.courseOrg} ${courseData.courseNumber}`)).toBeInTheDocument();
-    expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();
+        expect(screen.getByAltText(`${courseData.courseOrg} logo`)).toHaveAttribute('src', 'logo-url');
+        expect(screen.getByText(`${courseData.courseOrg}`)).toBeInTheDocument();
+        expect(screen.getByText(courseData.courseTitle)).toBeInTheDocument();
+      },
+    );
   });
 });

--- a/src/learning-header/_header.scss
+++ b/src/learning-header/_header.scss
@@ -1,0 +1,10 @@
+@import "../../node_modules/bootstrap/scss/bootstrap-grid";
+@import "../../node_modules/bootstrap/scss/mixins/breakpoints";
+
+.logo {
+    img {
+        @include media-breakpoint-down(sm) {
+            max-width: 85% !important;
+        }
+    }
+}

--- a/src/learning-header/data/api.js
+++ b/src/learning-header/data/api.js
@@ -1,0 +1,22 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+const getCourseLogoOrg = async () => {
+  try {
+    const orgId = window.location.pathname.match(/course-(.*?):([^+]+)/)[2];
+    const { data } = await getAuthenticatedHttpClient()
+      .get(
+        `${getConfig().LMS_BASE_URL}/api/organizations/v0/organizations/${orgId}/`,
+        { useCache: true },
+      );
+    return data.logo;
+  } catch (error) {
+    const { httpErrorStatus } = error && error.customAttributes;
+    if (httpErrorStatus === 404) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+export default getCourseLogoOrg;

--- a/src/learning-header/data/api.js
+++ b/src/learning-header/data/api.js
@@ -4,7 +4,7 @@ import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-
 const getCourseLogoOrg = async () => {
   try {
     const orgId = window.location.pathname.match(/course-(.*?):([^+]+)/)[2];
-    const { username } = getAuthenticatedUser();
+    const { username } = getAuthenticatedUser() ?? {};
     if (username) {
       const { data } = await getAuthenticatedHttpClient()
         .get(
@@ -13,14 +13,10 @@ const getCourseLogoOrg = async () => {
         );
       return data.logo;
     }
-    return null;
   } catch (error) {
-    const { httpErrorStatus } = error && error.customAttributes;
-    if (httpErrorStatus === 404) {
-      return null;
-    }
-    throw error;
+    console.warn('Error fetching course org logo:', error);
   }
+  return null;
 };
 
 export default getCourseLogoOrg;

--- a/src/learning-header/data/api.js
+++ b/src/learning-header/data/api.js
@@ -1,15 +1,19 @@
 import { getConfig } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 const getCourseLogoOrg = async () => {
   try {
     const orgId = window.location.pathname.match(/course-(.*?):([^+]+)/)[2];
-    const { data } = await getAuthenticatedHttpClient()
-      .get(
-        `${getConfig().LMS_BASE_URL}/api/organizations/v0/organizations/${orgId}/`,
-        { useCache: true },
-      );
-    return data.logo;
+    const { username } = getAuthenticatedUser();
+    if (username) {
+      const { data } = await getAuthenticatedHttpClient()
+        .get(
+          `${getConfig().LMS_BASE_URL}/api/organizations/v0/organizations/${orgId}/`,
+          { useCache: true },
+        );
+      return data.logo;
+    }
+    return null;
   } catch (error) {
     const { httpErrorStatus } = error && error.customAttributes;
     if (httpErrorStatus === 404) {

--- a/src/learning-header/data/api.js
+++ b/src/learning-header/data/api.js
@@ -1,5 +1,6 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
 
 const getCourseLogoOrg = async () => {
   try {
@@ -14,7 +15,8 @@ const getCourseLogoOrg = async () => {
       return data.logo;
     }
   } catch (error) {
-    console.warn('Error fetching course org logo:', error);
+    // do not throw the error, just log it, the Course Org Logo is not critical
+    logError(error);
   }
   return null;
 };

--- a/src/learning-header/data/api.test.js
+++ b/src/learning-header/data/api.test.js
@@ -1,0 +1,59 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import getCourseLogoOrg from './api';
+import { initializeMockApp } from '../../setupTest';
+
+jest.mock('@edx/frontend-platform/auth');
+
+class CustomError extends Error {
+  constructor(httpErrorStatus) {
+    super();
+    this.customAttributes = {
+      httpErrorStatus,
+    };
+  }
+}
+
+describe('getCourseLogoOrg', () => {
+  beforeEach(async () => {
+    // We need to mock AuthService to implicitly use `getAuthenticatedHttpClient` within `AppContext.Provider`.
+    await initializeMockApp();
+    delete window.location;
+    getAuthenticatedHttpClient.mockReset();
+  });
+
+  it('should return the organization logo when the URL is valid', async () => {
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => Promise.resolve({
+        data: {
+          logo: 'https://example.com/logo.svg',
+        },
+      }),
+    });
+    const logoOrg = await getCourseLogoOrg();
+    expect(logoOrg).toBe('https://example.com/logo.svg');
+  });
+
+  it('should return null when the organization logo is not found', async () => {
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Nonexistent_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => {
+        throw new CustomError(404);
+      },
+    });
+    const logoOrg = await getCourseLogoOrg();
+    expect(logoOrg).toBeNull();
+  });
+
+  it('should throw an error when an unexpected error occurs', async () => {
+    const customError = new CustomError(500);
+    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    getAuthenticatedHttpClient.mockReturnValue({
+      get: async () => {
+        throw customError;
+      },
+    });
+    await expect(getCourseLogoOrg()).rejects.toThrow(customError);
+  });
+});

--- a/src/learning-header/data/api.test.js
+++ b/src/learning-header/data/api.test.js
@@ -1,9 +1,13 @@
+import { logError } from '@edx/frontend-platform/logging';
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import getCourseLogoOrg from './api';
 import { initializeMockApp } from '../../setupTest';
 
 jest.mock('@edx/frontend-platform/auth');
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
 
 class CustomError extends Error {
   constructor(httpErrorStatus) {
@@ -73,6 +77,8 @@ describe('getCourseLogoOrg', () => {
         throw customError;
       },
     });
-    await expect(getCourseLogoOrg()).rejects.toThrow(customError);
+    const logoOrg = await getCourseLogoOrg();
+    expect(logoOrg).toBeNull();
+    expect(logError).toHaveBeenCalledWith(customError);
   });
 });

--- a/src/learning-header/data/api.test.js
+++ b/src/learning-header/data/api.test.js
@@ -1,5 +1,4 @@
 import { logError } from '@edx/frontend-platform/logging';
-import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import getCourseLogoOrg from './api';
 import { initializeMockApp } from '../../setupTest';
@@ -19,30 +18,40 @@ class CustomError extends Error {
 }
 
 describe('getCourseLogoOrg', () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     // We need to mock AuthService to implicitly use `getAuthenticatedHttpClient` within `AppContext.Provider`.
     await initializeMockApp();
-    delete window.location;
+  });
+
+  beforeEach(() => {
     getAuthenticatedHttpClient.mockReset();
     getAuthenticatedUser.mockReset();
+    logError.mockReset();
   });
 
   it('should return the organization logo when the URL is valid', async () => {
-    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    // Use history.pushState to change the URL
+    window.history.pushState({}, '', '/learning/course/course-v1:edX+DemoX+Demo_Course/home');
+
     getAuthenticatedUser.mockImplementation(() => ({ username: 'someone' }));
+    const mockGet = jest.fn().mockResolvedValue({
+      data: {
+        logo: 'https://example.com/logo.svg',
+      },
+    });
     getAuthenticatedHttpClient.mockReturnValue({
-      get: async () => Promise.resolve({
-        data: {
-          logo: 'https://example.com/logo.svg',
-        },
-      }),
+      get: mockGet,
     });
     const logoOrg = await getCourseLogoOrg();
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('/api/organizations/v0/organizations/edX/'),
+      { useCache: true },
+    );
     expect(logoOrg).toBe('https://example.com/logo.svg');
   });
 
   it('should return null when the organization logo is not found', async () => {
-    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Nonexistent_Course/home`);
+    window.history.pushState({}, '', '/learning/course/course-v1:edX+DemoX+Nonexistent_Course/home');
     getAuthenticatedUser.mockImplementation(() => ({ username: 'someone' }));
     getAuthenticatedHttpClient.mockReturnValue({
       get: async () => {
@@ -54,7 +63,7 @@ describe('getCourseLogoOrg', () => {
   });
 
   it('should return null if the user is not authenticated', async () => {
-    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
+    window.history.pushState({}, '', '/learning/course/course-v1:edX+DemoX+Demo_Course/home');
     getAuthenticatedUser.mockImplementation(() => ({}));
     getAuthenticatedHttpClient.mockReturnValue({
       get: async () => Promise.resolve({
@@ -69,9 +78,10 @@ describe('getCourseLogoOrg', () => {
   });
 
   it('should throw an error when an unexpected error occurs', async () => {
+    window.history.pushState({}, '', '/learning/course/course-v1:edX+DemoX+Demo_Course/home');
+
     getAuthenticatedUser.mockImplementation(() => ({ username: 'someone' }));
     const customError = new CustomError(500);
-    window.location = new URL(`${getConfig().BASE_URL}/learning/course/course-v1:edX+DemoX+Demo_Course/home`);
     getAuthenticatedHttpClient.mockReturnValue({
       get: async () => {
         throw customError;

--- a/src/studio-header/HeaderBody.tsx
+++ b/src/studio-header/HeaderBody.tsx
@@ -80,7 +80,7 @@ const HeaderBody = ({
               </Button>
             ) : (
               <div className="w-25">
-                <Row className="m-0 flex-nowrap">
+                <Row className="m-0 flex-nowrap align-items-center">
                   {renderBrandNav}
                   <CourseLockUp
                     {...{

--- a/src/studio-header/StudioHeader.scss
+++ b/src/studio-header/StudioHeader.scss
@@ -4,8 +4,6 @@ $white: #FFFFFF;
 .studio-header {
   position: relative;
   z-index: 1000;
-
-  height: 3.75rem;
   box-shadow: 0 1px 0 0 rgb(0 0 0 / .1);
   background: var(--pgn-color-white, $white);
 


### PR DESCRIPTION
Release version to deploy [PR #26](https://github.com/fccn/frontend-component-header-nau/pull/26)

Adds a missing import and renders <LearningHelpSlot /> just before <AuthenticatedUserDropdown /> inside the authenticated user block, matching the position used in the upstream header.