### PR TITLE
fix: show hydrated profile avatars in Studio header

### DIFF
--- a/src/studio-header/StudioHeader.test.tsx
+++ b/src/studio-header/StudioHeader.test.tsx
@@ -122,6 +122,53 @@ describe('Header', () => {
       expect(avatarIcon).toBeVisible();
     });
 
+    it('user menu should use avatar icon when hydrated profile image has no image', async () => {
+      currentUser = {
+        ...authenticatedUser,
+        avatar: null,
+        profileImage: {
+          hasImage: false,
+          imageUrlMedium: '/profile-images/abc123-medium.png',
+        },
+      };
+      const { getByTestId, queryByTestId } = render(<RootWrapper {...props} />);
+      const avatarIcon = getByTestId('avatar-icon');
+
+      expect(avatarIcon).toBeVisible();
+      expect(queryByTestId('avatar-image')).not.toBeInTheDocument();
+    });
+
+    it('user menu should use hydrated profile image when avatar is not present', async () => {
+      currentUser = {
+        ...authenticatedUser,
+        avatar: null,
+        profileImage: {
+          hasImage: true,
+          imageUrlMedium: '/profile-images/abc123-medium.png',
+        },
+      };
+      const { getByTestId } = render(<RootWrapper {...props} />);
+      const avatarImage = getByTestId('avatar-image');
+
+      expect(avatarImage).toBeVisible();
+      expect(avatarImage).toHaveAttribute('src', '/profile-images/abc123-medium.png');
+    });
+
+    it('user menu should prefer avatar over hydrated profile image', async () => {
+      currentUser = {
+        ...authenticatedUser,
+        profileImage: {
+          hasImage: true,
+          imageUrlMedium: '/profile-images/abc123-medium.png',
+        },
+      };
+      const { getByTestId } = render(<RootWrapper {...props} />);
+      const avatarImage = getByTestId('avatar-image');
+
+      expect(avatarImage).toBeVisible();
+      expect(avatarImage).toHaveAttribute('src', authenticatedUser.avatar);
+    });
+
     it('should hide nav items if prop isHiddenMainMenu true', async () => {
       const initialProps = { ...props, isHiddenMainMenu: true };
       const { queryByTestId } = render(<RootWrapper {...initialProps} />);

--- a/src/studio-header/StudioHeader.tsx
+++ b/src/studio-header/StudioHeader.tsx
@@ -40,6 +40,9 @@ const StudioHeader: FunctionComponent<Props> = ({
 }) => {
   // @ts-expect-error - frontend-platform doesn't yet have type information :/
   const { authenticatedUser, config } = useContext(AppContext);
+  const profileImage = authenticatedUser?.profileImage;
+  const authenticatedUserAvatar = authenticatedUser?.avatar
+    || (profileImage?.hasImage ? profileImage.imageUrlMedium : null);
   const props = {
     logo: config.LOGO_URL,
     logoAltText: `Studio ${config.SITE_NAME}`,
@@ -49,7 +52,7 @@ const StudioHeader: FunctionComponent<Props> = ({
     containerProps,
     username: authenticatedUser?.username,
     isAdmin: authenticatedUser?.administrator,
-    authenticatedUserAvatar: authenticatedUser?.avatar,
+    authenticatedUserAvatar,
     studioBaseUrl: isNewHomePage ? '/home' : config.STUDIO_BASE_URL,
     logoutUrl: config.LOGOUT_URL,
     isHiddenMainMenu,


### PR DESCRIPTION
## Description

Studio header avatar rendering currently only checks `authenticatedUser.avatar`. That preserves the legacy header avatar contract, but it misses uploaded Open edX profile images because those image URLs are returned by the hydrated account payload under `authenticatedUser.profileImage`.

This change keeps the existing `authenticatedUser.avatar` behavior and adds a fallback to hydrated account profile image data when available:

- prefer `authenticatedUser.avatar`
- otherwise use `authenticatedUser.profileImage.imageUrlMedium` when `profileImage.hasImage` is true
- otherwise preserve the existing Paragon fallback avatar behavior

This does not change backend profile-image APIs, JWT contents, or fallback rendering responsibilities.

## Supporting Context

The corresponding Studio app change should enable authenticated-user hydration in `frontend-app-authoring`. That app-level change should be staged after this package change is released, because Studio must consume the released `@edx/frontend-component-header` version containing this normalization.

## Testing

```bash
npm test -- --runTestsByPath src/studio-header/StudioHeader.test.tsx --runInBand
npm run types
```

The targeted test suite covers:

- no uploaded image fallback
- hydrated `profileImage.hasImage: false` fallback
- hydrated `profileImage.hasImage: true` image rendering
- legacy `authenticatedUser.avatar` priority

## Future work
Avatar needs to be fixed for the LMS/ new Instructor Dashboard as well. Those were left to keep the scope of this PR tight. 

## AI Disclosure
Codex was used to help diagnose the bug, catalog the current behavior, suggest an implementation shape, execute the fix, and generate the framework for the PR text based on Open edX guidances in the docs. Each step required manual review to avoid scope creep and to ensure the fix was well defined. 
