### PR TITLE
feat: render initials avatar as default instead of generic icon

### DIFF
--- a/src/Avatar.jsx
+++ b/src/Avatar.jsx
@@ -2,18 +2,36 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { AvatarIcon } from './Icons';
+import { getAvatarColor, getInitial } from './avatarUtils';
 
 const Avatar = ({
   size,
   src,
   alt,
   className,
+  username,
 }) => {
-  const avatar = src ? (
-    <img className="d-block w-100 h-100" src={src} alt={alt} />
-  ) : (
-    <AvatarIcon style={{ width: size, height: size }} role="img" aria-hidden focusable="false" />
-  );
+  let avatar;
+  if (src) {
+    avatar = <img className="d-block w-100 h-100" src={src} alt={alt} />;
+  } else if (username) {
+    avatar = (
+      <span
+        className="d-flex w-100 h-100 align-items-center justify-content-center font-weight-bold"
+        style={{
+          backgroundColor: getAvatarColor(username),
+          color: '#FFFFFF',
+          fontSize: `calc(${size} * 0.55)`,
+        }}
+        role="img"
+        aria-hidden
+      >
+        {getInitial(username)}
+      </span>
+    );
+  } else {
+    avatar = <AvatarIcon style={{ width: size, height: size }} role="img" aria-hidden focusable="false" />;
+  }
 
   return (
     <span
@@ -30,6 +48,7 @@ Avatar.propTypes = {
   size: PropTypes.string,
   alt: PropTypes.string,
   className: PropTypes.string,
+  username: PropTypes.string,
 };
 
 Avatar.defaultProps = {
@@ -37,6 +56,7 @@ Avatar.defaultProps = {
   size: '2rem',
   alt: null,
   className: null,
+  username: null,
 };
 
 export default Avatar;

--- a/src/avatarUtils.js
+++ b/src/avatarUtils.js
@@ -1,0 +1,31 @@
+// Paragon light-theme tokens (primary/brand/success/info/danger families),
+// chosen for WCAG-safe contrast with white text.
+export const AVATAR_COLORS = [
+  '#0A3055', // primary
+  '#9D0054', // brand
+  '#178253', // success (green)
+  '#006DAA', // info (teal)
+  '#C32D3A', // danger (red)
+  '#476480', // primary-400
+  '#B6407F', // brand-400
+  '#15754B', // success-600
+  '#006299', // info-600
+  '#B02934', // danger-600
+];
+
+/**
+ * Returns a deterministic background color for the given username.
+ * Same username always maps to the same palette color.
+ */
+export const getAvatarColor = (username) => {
+  let hash = 0;
+  for (let i = 0; i < username.length; i += 1) {
+    hash = ((hash << 5) - hash + username.charCodeAt(i)) | 0; // eslint-disable-line no-bitwise
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+};
+
+/**
+ * Returns the uppercased first character of the username.
+ */
+export const getInitial = (username) => username.charAt(0).toUpperCase();

--- a/src/desktop-header/DesktopUserMenuToggle.jsx
+++ b/src/desktop-header/DesktopUserMenuToggle.jsx
@@ -5,7 +5,7 @@ import Avatar from '../Avatar';
 
 const DesktopUserMenuToggle = ({ avatar, label }) => (
   <>
-    <Avatar size="1.5em" src={avatar} alt="" className="mr-2" />
+    <Avatar size="1.5em" src={avatar} alt="" className="mr-2" username={label} />
     {label} <CaretIcon role="img" aria-hidden focusable="false" />
   </>
 );

--- a/src/mobile-header/MobileUserMenuToggle.jsx
+++ b/src/mobile-header/MobileUserMenuToggle.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '../Avatar';
 
-const MobileUserMenuToggle = ({ avatar, username }) => <Avatar size="1.5rem" src={avatar} alt={username} />;
+const MobileUserMenuToggle = ({ avatar, username, label }) => (
+  <Avatar size="1.5rem" src={avatar} alt={username || label} username={username || label} />
+);
 
 export const MobileUserMenuTogglePropTypes = {
   avatar: PropTypes.string,
   username: PropTypes.string,
+  label: PropTypes.string,
 };
 
 MobileUserMenuToggle.propTypes = MobileUserMenuTogglePropTypes;

--- a/src/studio-header/UserMenu.tsx
+++ b/src/studio-header/UserMenu.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Avatar,
-} from '@openedx/paragon';
+import Avatar from '../Avatar';
 import NavDropdownMenu from './NavDropdownMenu';
 import getUserMenuItems from './utils';
 
@@ -24,12 +22,14 @@ const UserMenu = ({
       data-testid="avatar-image"
     />
   ) : (
-    <Avatar
-      size="sm"
-      className="mr-2"
-      alt={username}
-      data-testid="avatar-icon"
-    />
+    <span data-testid="avatar-icon">
+      <Avatar
+        size="1.5rem"
+        className="mr-2"
+        alt={username}
+        username={username}
+      />
+    </span>
   );
   const title = isMobile ? avatar : <>{avatar}{username}</>;
 


### PR DESCRIPTION
## Description

When a user has no profile photo, the header currently shows a generic grey silhouette (a bundled SVG). This PR replaces that fallback with a personalized initials avatar: a colored circle with the username's first letter, rendered entirely client-side.

**This preserves the exact economics of today's default avatar: zero API calls, zero server compute, nothing generated or stored.** The username is already available in every MFE from the decoded JWT cookie (`authenticatedUser.username`) — no `hydrateAuthenticatedUser` needed. The initials avatar is plain HTML/CSS, computationally equivalent to the grey SVG it replaces.

### How it works

1. **`src/avatarUtils.js` (new):** `getInitial(username)` returns the uppercased first letter; `getAvatarColor(username)` hashes the username into a fixed 10-color palette (Paragon light-theme tokens, WCAG-safe with white text — same palette reviewed in openedx/openedx-platform#38638). Deterministic: same username → same color everywhere, nothing persisted.
2. **`src/Avatar.jsx`:** the render logic gains a middle branch — photo URL → `<img>` (unchanged); no photo but username present → initials circle; neither (logged out) → the generic icon, unchanged.
3. **`DesktopUserMenuToggle` / `MobileUserMenuToggle` / studio-header `UserMenu`:** thread the username (already in scope at each call site) down to the avatar render.

Every MFE that consumes this package inherits the new default via its normal dependency bump — no per-MFE changes.

### Screenshots

| Before | After |
|---|---|
| Grey silhouette | Colored circle with initial (e.g. "A" for `admin` on the brand color) |

<img width="1021" height="267" alt="Screenshot 2026-06-12 at 2 01 50 PM" src="https://github.com/user-attachments/assets/072aaab2-3bd4-497a-90f8-fbffd3eee199" />


### Context

This is **a draft / proof of concept** supporting the discussion in [openedx/openedx-platform#38638](https://github.com/openedx/openedx-platform/pull/38638) (see [the update comment](https://github.com/openedx/openedx-platform/pull/38638#issuecomment-4686629676)) about moving default-avatar generation from the server to the client. It implements "Option 1" (local fallback at each avatar surface) for the header — the surface that covers the most MFEs at once.

Related community thread: [Profile Avatar Modernization](https://discuss.openedx.org/t/profile-avatar-modernization/19046).

Tests are intentionally not updated yet — pending community feedback on the direction before investing in full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
